### PR TITLE
404 site not found fixed

### DIFF
--- a/index.html
+++ b/index.html
@@ -13,7 +13,7 @@
 <body>
   <nav class="navbar bg-body-tertiary fixed-top pink-bg">
     <div class="container-fluid d-flex justify-content-between align-items-center">
-      <a class="navbar-brand pink-text" href="/"> <b>TravelTales:) </b> </a>
+      <a class="navbar-brand pink-text" href="/TravelTales"> <b>TravelTales:) </b> </a>
       <button class="navbar-toggler" type="button" data-bs-toggle="offcanvas" data-bs-target="#offcanvasNavbar"
         aria-controls="offcanvasNavbar" aria-label="Toggle navigation">
         <span class="navbar-toggler-icon"></span>


### PR DESCRIPTION
When clicked on logo on the navbar, 404 site not found error appear. 

![image](https://github.com/amrit03b/TravelTales/assets/20722868/55e0028a-0f0c-4944-aae6-9dadc06d3004)


Solution:
Updated the homepage href