### PR TITLE
make cards center in tablet Ui

### DIFF
--- a/style.css
+++ b/style.css
@@ -141,6 +141,7 @@ a #titled:hover{
 {
     display: flex;
     gap: 20px;
+    justify-content: center;
 }
 
 .card {


### PR DESCRIPTION
When opening website in the tablet, cards stuck left instead we should make it center

before 
<img width="561" alt="image" src="https://github.com/amrit03b/TravelTales/assets/58323485/e5ef191f-c365-4e92-9363-3887bd27515a">


after
<img width="615" alt="image" src="https://github.com/amrit03b/TravelTales/assets/58323485/cb8e0df6-2f0f-4e3b-9f9f-fe34594fd38f">

please add hacktoberfest label